### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "context-creator"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 description = "High-performance CLI tool to convert codebases to Markdown for LLM context"
 authors = ["Matias Villaverde"]

--- a/tests/modules/binary_name_test.rs
+++ b/tests/modules/binary_name_test.rs
@@ -22,7 +22,7 @@ fn test_version_output_contains_new_name() {
         .assert()
         .success()
         .stdout(predicate::str::contains("context-creator"))
-        .stdout(predicate::str::contains("1.0.0"));
+        .stdout(predicate::str::contains("1.0.1"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Bump version from 1.0.0 to 1.0.1
- Update version test to match new version

## Changes
- Updated version in Cargo.toml
- Fixed test that was checking for version 1.0.0

## Release Status
- ✅ Tag v1.0.1 created and pushed
- ✅ GitHub release created (by GitHub Actions)
- ✅ Published to crates.io

This PR merges the version bump commits back to main.