### PR TITLE
chore: bump version to 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,31 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- FileCache for eliminating redundant I/O operations
-- Parallel token counting for improved performance
-- Memory optimization with pre-allocated string buffers
-- Performance benchmark for 1000 files
-- Integration test verifying <1 second processing for 1000 files
-- Enhanced `--include-types` functionality to include actual type definition files instead of just listing type names
-- New `file_expander` module for expanding file lists based on semantic relationships
-- Type reference extraction from Rust imports (including traits)
-- Path validation security checks for expanded files
-- Support for finding trait definitions when used as type references
-
-### Changed
-- Optimized file reading to eliminate 2-3x redundant I/O operations
-- Improved token counting with parallel processing using rayon
-- Enhanced memory efficiency in markdown generation
-- **BREAKING**: Default `semantic_depth` changed from 3 to 2 for better performance with expanded file inclusion
-- `TypeReference` struct enhanced with `definition_path`, `is_external`, and `external_package` fields
-- File expansion now respects `semantic_depth` limit to prevent unbounded traversal
+## [1.0.2] - 2025-07-21
 
 ### Performance
-- Reduced processing time for 1000 files from >5 seconds to <100ms (50x improvement)
-- Eliminated redundant file reads through shared caching
-- Reduced memory allocations with pre-sized string buffers
-- File expansion uses FileCache to avoid redundant I/O when searching for type definitions
+- Replaced O(n²) contains checks with HashSet for O(1) lookups
+- Added semantic analysis caching to avoid redundant parsing
+- Implemented single-pass directory walking for semantic analysis
+- Removed debug eprintln statements for performance
+
+### Fixed
+- Restored backward compatibility for --include-callers when no context provided
+- Resolved Python imports and Rust super:: imports in semantic analysis
 
 ## [0.3.0] - 2025-01-12
 
@@ -81,7 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First public release
 
-[Unreleased]: https://github.com/matiasvillaverde/context-creator/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/matiasvillaverde/context-creator/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/matiasvillaverde/context-creator/compare/v0.3.0...v1.0.2
 [0.3.0]: https://github.com/matiasvillaverde/context-creator/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/matiasvillaverde/context-creator/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/matiasvillaverde/context-creator/compare/v0.1.0...v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "context-creator"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 description = "High-performance CLI tool to convert codebases to Markdown for LLM context"
 authors = ["Matias Villaverde"]

--- a/tests/modules/binary_name_test.rs
+++ b/tests/modules/binary_name_test.rs
@@ -22,7 +22,7 @@ fn test_version_output_contains_new_name() {
         .assert()
         .success()
         .stdout(predicate::str::contains("context-creator"))
-        .stdout(predicate::str::contains("1.0.1"));
+        .stdout(predicate::str::contains("1.0.2"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Update version to 1.0.2
- Update CHANGELOG.md with release notes
- Fix version test to expect new version

## Release Notes

### Performance Improvements 🚀
- Replaced O(n²) contains checks with HashSet for O(1) lookups
- Added semantic analysis caching to avoid redundant parsing
- Implemented single-pass directory walking for semantic analysis
- Removed debug eprintln statements for performance

### Bug Fixes 🐛
- Restored backward compatibility for --include-callers when no context provided
- Resolved Python imports and Rust super:: imports in semantic analysis

## Test Plan
✅ All tests pass
✅ Version published to crates.io
✅ GitHub release created (v1.0.2)

🤖 Generated with [Claude Code](https://claude.ai/code)