### PR TITLE
test: enable previously ignored tests that now pass

### DIFF
--- a/tests/modules/config_rename_test.rs
+++ b/tests/modules/config_rename_test.rs
@@ -87,7 +87,6 @@ quiet = true
 }
 
 #[test]
-#[ignore = "Flaky on macOS CI - test only runs --help and doesn't actually test ignore patterns"]
 fn test_ignore_file_patterns_updated() {
     let temp_dir = TempDir::new().unwrap();
 

--- a/tests/modules/python_semantic_edge_cases_test.rs
+++ b/tests/modules/python_semantic_edge_cases_test.rs
@@ -559,7 +559,6 @@ if __name__ == "__main__":
 
 /// Test Python with complex package structure
 #[test]
-#[ignore = "Issue with import display: 'from myapp import App' shows as 'Imports: app' instead of 'Imports: myapp'. The import resolution correctly finds the App class in myapp/core/app.py, but the display logic shows the final resolved filename rather than the original module name from the import statement."]
 fn test_python_complex_package_structure() {
     let temp_dir = TempDir::new().unwrap();
     let root = temp_dir.path();


### PR DESCRIPTION
## Summary
- Enable `test_python_complex_package_structure` - import display issue has been resolved
- Enable `test_ignore_file_patterns_updated` - no longer flaky on macOS CI

## Test plan
Both tests have been verified to pass consistently:

```bash
cargo test test_python_complex_package_structure
cargo test test_ignore_file_patterns_updated
```

✅ All tests pass
✅ Code validation (fmt + clippy) passes

🤖 Generated with [Claude Code](https://claude.ai/code)