### PR TITLE
feat: add npm publishing for MCP server distribution

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,246 @@
+name: Build and Publish NPM Package
+
+on:
+  push:
+    tags:
+      - 'v*'  # Trigger on version tags like v1.0.0
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  build-binaries:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            binary_name: context-creator-darwin-x64
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            binary_name: context-creator-darwin-arm64
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            binary_name: context-creator-linux-x64
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            binary_name: context-creator-linux-arm64
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            binary_name: context-creator-win32-x64.exe
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation tools (Linux ARM64)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+
+      - name: Build binary
+        run: cargo build --release --target ${{ matrix.target }} --all-features
+
+      - name: Prepare binary (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          mkdir -p binaries
+          cp target/${{ matrix.target }}/release/context-creator binaries/${{ matrix.binary_name }}
+          chmod +x binaries/${{ matrix.binary_name }}
+
+      - name: Prepare binary (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          mkdir binaries
+          copy target\${{ matrix.target }}\release\context-creator.exe binaries\${{ matrix.binary_name }}
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-${{ matrix.target }}
+          path: binaries/${{ matrix.binary_name }}
+
+  publish-npm:
+    name: Publish to NPM
+    needs: build-binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download all binary artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare npm package structure
+        run: |
+          mkdir -p npm-package/binaries
+          mkdir -p npm-package/bin
+          
+          # Copy all binaries
+          find artifacts -name "context-creator-*" -exec cp {} npm-package/binaries/ \;
+          
+          # Make binaries executable
+          chmod +x npm-package/binaries/*
+
+      - name: Create package.json
+        run: |
+          # Extract version without 'v' prefix
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          
+          cat > npm-package/package.json << EOF
+          {
+            "name": "context-creator-mcp",
+            "version": "$VERSION",
+            "description": "High-performance CLI tool to convert codebases to Markdown for LLM context - MCP Server",
+            "main": "index.js",
+            "bin": {
+              "context-creator-mcp": "./bin/context-creator.js"
+            },
+            "keywords": [
+              "mcp",
+              "mcp-server",
+              "llm", 
+              "context",
+              "ai",
+              "development",
+              "claude",
+              "rust",
+              "markdown",
+              "codebase",
+              "context-window"
+            ],
+            "author": "Matias Villaverde",
+            "license": "MIT",
+            "repository": {
+              "type": "git",
+              "url": "https://github.com/${{ github.repository }}.git"
+            },
+            "homepage": "https://github.com/${{ github.repository }}#readme",
+            "bugs": {
+              "url": "https://github.com/${{ github.repository }}/issues"
+            },
+            "engines": {
+              "node": ">=16.0.0"
+            },
+            "os": [
+              "darwin",
+              "linux",
+              "win32"
+            ],
+            "cpu": [
+              "x64",
+              "arm64"
+            ],
+            "files": [
+              "bin/",
+              "binaries/",
+              "README.md"
+            ]
+          }
+          EOF
+
+      - name: Create wrapper script
+        run: |
+          cat > npm-package/bin/context-creator.js << 'EOF'
+          #!/usr/bin/env node
+          
+          const { spawn } = require('child_process');
+          const path = require('path');
+          const fs = require('fs');
+          const os = require('os');
+          
+          function getBinaryName() {
+            const platform = os.platform();
+            const arch = os.arch();
+            
+            const archMap = {
+              'x64': 'x64',
+              'arm64': 'arm64'
+            };
+            
+            const platformMap = {
+              'darwin': 'darwin',
+              'linux': 'linux',
+              'win32': 'win32'
+            };
+            
+            const mappedArch = archMap[arch] || 'x64';
+            const mappedPlatform = platformMap[platform] || 'linux';
+            
+            const extension = platform === 'win32' ? '.exe' : '';
+            return `context-creator-${mappedPlatform}-${mappedArch}${extension}`;
+          }
+          
+          function getBinaryPath() {
+            const binaryName = getBinaryName();
+            return path.join(__dirname, '..', 'binaries', binaryName);
+          }
+          
+          function main() {
+            const binaryPath = getBinaryPath();
+            
+            if (!fs.existsSync(binaryPath)) {
+              console.error(`Binary not found: ${binaryPath}`);
+              console.error(`Platform: ${os.platform()}-${os.arch()}`);
+              process.exit(1);
+            }
+            
+            // Make executable on Unix
+            if (os.platform() !== 'win32') {
+              try {
+                fs.chmodSync(binaryPath, '755');
+              } catch (err) {
+                console.warn('Warning: Could not set permissions:', err.message);
+              }
+            }
+            
+            // Add --rmcp flag for MCP mode if not present
+            const args = process.argv.slice(2);
+            if (!args.includes('--rmcp')) {
+              args.push('--rmcp');
+            }
+            
+            const child = spawn(binaryPath, args, {
+              stdio: 'inherit',
+              env: process.env
+            });
+            
+            process.on('SIGINT', () => child.kill('SIGINT'));
+            process.on('SIGTERM', () => child.kill('SIGTERM'));
+            
+            child.on('close', (code) => process.exit(code));
+            child.on('error', (err) => {
+              console.error('Failed to start context-creator:', err.message);
+              process.exit(1);
+            });
+          }
+          
+          main();
+          EOF
+          
+          chmod +x npm-package/bin/context-creator.js
+
+      - name: Copy README
+        run: cp README.md npm-package/ || echo "README.md not found, skipping"
+
+      - name: Publish to NPM
+        working-directory: npm-package
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds GitHub Action workflow to publish context-creator as an MCP server on npm
- Enables installation via Claude Code: `claude mcp add context-creator -- npx -y context-creator-mcp`
- Publishes under package name `context-creator-mcp` to avoid naming conflicts

## Changes
- New workflow `.github/workflows/npm-publish.yml` that:
  - Triggers on version tags (`v*`) and manual dispatch
  - Builds binaries for all platforms (macOS x64/arm64, Linux x64/arm64, Windows x64)
  - Creates npm package with wrapper script that auto-adds `--rmcp` flag
  - Publishes to npm registry using NPM_TOKEN secret

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test with a pre-release tag to ensure npm publishing works
- [ ] Confirm MCP server mode activates with `--rmcp` flag
- [ ] Test installation via `npx -y context-creator-mcp`

🤖 Generated with [Claude Code](https://claude.ai/code)