### PR TITLE
fix: resolve OpenSSL build issues in npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -38,6 +38,13 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install openssl@3
+          echo "OPENSSL_DIR=$(brew --prefix openssl@3)" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=$(brew --prefix openssl@3)/lib/pkgconfig" >> $GITHUB_ENV
+
       - name: Install cross-compilation tools (Linux ARM64)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
@@ -46,10 +53,7 @@ jobs:
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
       - name: Build binary
-        run: |
-          # Use vendored OpenSSL to avoid build issues on macOS
-          export OPENSSL_STATIC=1
-          cargo build --release --target ${{ matrix.target }} --all-features
+        run: cargo build --release --target ${{ matrix.target }} --all-features
 
       - name: Prepare binary (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary
- Fixes OpenSSL build failures on macOS in the npm-publish workflow
- Adds explicit OpenSSL installation step for macOS runners
- Sets required environment variables for the build process

## Changes
- Install OpenSSL via Homebrew on macOS runners
- Set OPENSSL_DIR and PKG_CONFIG_PATH environment variables
- Remove ineffective OPENSSL_STATIC export

## Test plan
- [ ] Merge and trigger the workflow with manual dispatch
- [ ] Verify all platform builds succeed
- [ ] Test npm package installation locally

🤖 Generated with [Claude Code](https://claude.ai/code)