### PR TITLE
fix: use vendored dependencies to resolve CI build failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ arboard = "3.2"
 clap = { version = "4.5", features = ["derive"] }
 dashmap = "5.5"
 dirs = "5.0"
-git2 = "0.20.1"
+git2 = { version = "0.20.1", features = ["vendored-libgit2", "vendored-openssl"] }
 glob = "0.3"
 ignore = "0.4"
 itertools = "0.13"


### PR DESCRIPTION
## Summary
- Uses vendored dependencies for git2 to avoid OpenSSL linking issues
- Fixes build failures across all platforms in the npm-publish workflow

## Changes
- Updated git2 dependency to use vendored-libgit2 and vendored-openssl features
- This bundles the dependencies instead of requiring system libraries

## Benefits
- No need to install OpenSSL on CI runners
- Consistent builds across all platforms
- Faster CI builds (no dependency installation)

## Test plan
- [ ] CI passes on all platforms
- [ ] npm-publish workflow succeeds after merge
- [ ] Binary sizes are acceptable (vendoring adds ~2-3MB)

🤖 Generated with [Claude Code](https://claude.ai/code)