### PR TITLE
fix: handle version correctly in npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -106,9 +106,14 @@ jobs:
 
       - name: Create package.json
         run: |
-          # Extract version without 'v' prefix
-          VERSION="${{ github.ref_name }}"
-          VERSION="${VERSION#v}"
+          # Extract version from Cargo.toml or use ref_name if it's a tag
+          if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            VERSION="${{ github.ref_name }}"
+            VERSION="${VERSION#v}"
+          else
+            VERSION=$(grep '^version' Cargo.toml | cut -d'"' -f2)
+            VERSION="${VERSION}-dev.${{ github.run_number }}"
+          fi
           
           cat > npm-package/package.json << EOF
           {


### PR DESCRIPTION
## Summary
- Fixes npm publish error: 'Invalid version: main'
- Extracts version from Cargo.toml when not triggered by a version tag
- Adds -dev suffix for manual workflow triggers

## Changes
- Modified package.json creation to handle both tag and manual triggers
- For tags: Uses tag version (e.g., v1.4.0 → 1.4.0)
- For manual runs: Uses Cargo.toml version + '-dev.RUN_NUMBER'

## Test plan
- [ ] Merge and trigger manually to test dev version
- [ ] Verify npm package publishes with correct version
- [ ] Test with actual version tag later

🤖 Generated with [Claude Code](https://claude.ai/code)