### PR TITLE
fix: add unit tests and exclude MCP integration tests from Cargo workflow

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -28,6 +28,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      - name: Run unit tests only (skip MCP integration tests)
+        run: cargo test --lib --bins
+        
       - name: Publish to crates.io
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
         env:


### PR DESCRIPTION
## Summary
- Adds unit test execution before publishing to crates.io
- Excludes MCP integration tests that fail in CI with connection refused errors
- Ensures code quality while allowing successful publishing

## Problem
MCP integration tests in CI were failing with:
- Connection refused errors (port 8124 not accessible)
- Server startup failures in CI environment  
- 285+ second timeout delays before failure

## Solution
- Run `cargo test --lib --bins` to test library and binary code only
- Skip integration tests that require server startup
- Maintain code quality validation before publishing

## Test Plan
- Unit tests will validate core functionality
- Integration tests can still be run locally during development
- Workflow should complete successfully without timeouts

🤖 Generated with [Claude Code](https://claude.ai/code)